### PR TITLE
[FIX] : menuSection 마지막 끼니 삭제시 activity indicator 계속 활성화 되는 문제 수정

### DIFF
--- a/components/common/menuSection/MenuSection.tsx
+++ b/components/common/menuSection/MenuSection.tsx
@@ -243,7 +243,7 @@ const MenuSection = () => {
         ),
       },
     ];
-  }, [dTOData, baseLineData, activeSection, isCreating]);
+  }, [dTOData, baseLineData, activeSection, isCreating, isDTOFetching]);
 
   // render
   return (


### PR DESCRIPTION
1. PROGRESS_ACCORDION content useMemo에 isDTOFetching dependency 추가