### PR TITLE
[FEAT] : DSlider - target price limit

### DIFF
--- a/cmd.txt
+++ b/cmd.txt
@@ -3,6 +3,9 @@
 # remove derived data
   rm -rf ~/Library/Developer/Xcode/DerivedData
 
+# SHA1 -> base64
+  echo {SHA1} | xxd -r -p | openssl base64
+
 
 ------------------ git --------------------
 
@@ -44,5 +47,9 @@
   eas update
   eas update --environment preview --channel preview
   eas update --environment production --channel production
+
+# eas submit
+  eas submit --profile production --platform ios
+  eas submit --profile production --platform android
 
 -------------------------------------------

--- a/components/screens/autoMenu/subScreens/Price.tsx
+++ b/components/screens/autoMenu/subScreens/Price.tsx
@@ -19,6 +19,7 @@ const Price = ({ priceSliderValue, setPriceSliderValue }: IPrice) => {
         setSliderValue={setPriceSliderValue}
         minimumValue={6000}
         maximumValue={12000}
+        value2LowerLimit={8000}
         step={1000}
         sliderWidth={SCREENWIDTH - 80}
       />

--- a/shared/ui/DSlider.tsx
+++ b/shared/ui/DSlider.tsx
@@ -12,6 +12,7 @@ interface IDSlider {
   minimumValue: number;
   maximumValue: number;
   step: number;
+  value2LowerLimit?: number;
   sliderWidth?: number;
   text?: string;
 }
@@ -23,6 +24,7 @@ const DSlider = ({
   minimumValue,
   maximumValue,
   step,
+  value2LowerLimit,
   sliderWidth,
   text,
 }: IDSlider) => {
@@ -32,9 +34,19 @@ const DSlider = ({
       <SliderContainer style={{ width }}>
         <Slider
           value={sliderValue}
-          onValueChange={(value) =>
-            Array.isArray(value) && setSliderValue(value)
-          }
+          onValueChange={(value) => {
+            if (!Array.isArray(value)) {
+              return;
+            }
+
+            if (!value2LowerLimit || value[1] >= value2LowerLimit) {
+              setSliderValue(value);
+              return;
+            }
+            const newValue = [...value];
+            newValue[1] = value2LowerLimit;
+            setSliderValue(newValue);
+          }}
           onSlidingComplete={onSlidingComplete}
           minimumValue={minimumValue}
           maximumValue={maximumValue}


### PR DESCRIPTION
가격 범위가 너무 좁으면 자동구성 에러 확률 증가
value2 가 8,000원 이하로는 범위 설정 안되도록 수정
(6,000원 ~ 7,000원은 설정 불가)